### PR TITLE
Add cursor: default - to the body element

### DIFF
--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -3,7 +3,8 @@ body {
   height: 100%;
   font-family: "Lora","Helvetica Neue",Helvetica,Arial,sans-serif;
   color: white;
-  background-color: black; }
+  background-color: black;
+  cursor: default; }
 
 html {
   width: 100%;


### PR DESCRIPTION
Practising branching and pull requests.

I have found it neat to keep the cursor's default behaviour. It makes the text elements
(headers, paragraphs) to be intertwined with background, so the user don't get distracted by the cursor changing its appearance every time the text paragraphs get hovered over.

Note: buttons and links override cursor's  default appearance set in the body element. 